### PR TITLE
chore(go): use go 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
 module github.com/Scalingo/cli-dl
 
-// +scalingo goVersion 1.15
-go 1.15
+// +scalingo goVersion 1.17
+go 1.17


### PR DESCRIPTION
The fix for CVE-2022-29526 is only available in Go 1.17 and 1.18.